### PR TITLE
Build UCRT64 DLLs in addition to MINGW64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        msystem: ["MINGW64", "UCRT64"]
     env:
-      MSYSTEM: MINGW64
+      MSYSTEM: ${{ matrix.msystem }}
 
     steps:
       - name: Checkout repository
@@ -21,8 +24,6 @@ jobs:
       - name: Check if today's tag exists
         id: tag
         run: |
-          export PATH="/mingw64/bin:/C/Program Files/Git/bin:$PATH"
-
           today="$(date +%Y%m%d)"
           tag="$(cat tag.txt)"
           if [ "$tag" = "$today" ]; then
@@ -36,18 +37,27 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.tag.outputs.skip == 'false' }}
         run: |
-           pacman -S --noconfirm --needed --noprogressbar make mingw-w64-x86_64-gcc
+          if [ "$MSYSTEM" = "MINGW64" ]; then
+          	pacman -S --noconfirm --needed --noprogressbar make mingw-w64-x86_64-gcc
+          else
+          	pacman -S --noconfirm --needed --noprogressbar make mingw-w64-ucrt-x86_64-gcc
+          fi
         shell: 'C:/shells/msys2bash.cmd {0}'
 
       - name: Build tree-sitter modules
         if: ${{ steps.tag.outputs.skip == 'false' }}
         id: build
         run: |
-          export PATH="/mingw64/bin:/C/Program Files/Git/bin:$PATH"
+          if [ "$MSYSTEM" = "MINGW64" ]; then
+          	export PATH="/mingw64/bin:/C/Program Files/Git/bin:$PATH"
+          else
+          	export PATH="/ucrt64/bin:/C/Program Files/Git/bin:$PATH"
+          fi
+          cc -v
 
           mkdir -p dist/licenses
 
-          git submodule foreach bash ../build.sh .
+          git submodule foreach bash ../build.sh . "$MSYSTEM"
           cp language-manifest.txt dist/
 
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
@@ -61,7 +71,11 @@ jobs:
         if: ${{ steps.tag.outputs.skip == 'false' }}
         id: archive
         run: |
-          $ARCHIVE = "emacs-tree-sitter-module-${{ steps.tag.outputs.tag }}.zip"
+          if ($env:MSYSTEM -eq "MINGW64") {
+              $ARCHIVE = "emacs-tree-sitter-module-${{ steps.tag.outputs.tag }}.zip"
+          } else {
+              $ARCHIVE = "emacs-tree-sitter-module-ucrt64-${{ steps.tag.outputs.tag }}.zip"
+          }
 
           cd dist
           Compress-Archive -Path *.dll,language-manifest.txt,licenses -DestinationPath "../$ARCHIVE"
@@ -75,9 +89,10 @@ jobs:
         if: ${{ steps.tag.outputs.skip == 'false' }}
         uses: ncipollo/release-action@v1
         with:
+          allowUpdates: true
           commit: '${{ github.sha }}'
           tag: '${{ steps.tag.outputs.tag }}'
-          artifacts: "emacs-tree-sitter-module-${{ steps.tag.outputs.tag }}.zip,sha256sum.txt"
+          artifacts: "emacs-tree-sitter-module-*.zip,sha256sum.txt"
           artifactContentType: application/octet-stream
           name: tree-sitter module DLLs ${{ steps.tag.outputs.tag }}
           body: |

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 CC=cc
+LDFLAGS='-shared'
 
 build() {
 	local dir=$1
@@ -18,9 +19,13 @@ build() {
 	elif [ -f scanner.cc ]; then
 		CC=c++
 		$CC -fPIC -I. -c scanner.cc
+		if [ "$MSYSTEM" = UCRT64 ]; then
+			LDFLAGS="-static-libstdc++ $LDFLAGS"
+		fi
 	fi
 
-	$CC -fPIC -shared ./*.o -o "$dest/libtree-sitter-${lang}.dll"
+	echo $CC -fPIC $LDFLAGS ./*.o -o "$dest/libtree-sitter-${lang}.dll"
+	$CC -fPIC $LDFLAGS ./*.o -o "$dest/libtree-sitter-${lang}.dll"
 
 	popd >/dev/null
 }
@@ -45,6 +50,9 @@ if [ "$dir" = . ]; then
 	lang=${lang##*/}
 else
 	lang=$dir
+fi
+if [ -n "$2" ]; then
+        export MSYSTEM=$2
 fi
 
 echo -n "Building $lang... "


### PR DESCRIPTION
UCRT64 Emacs needs "-static-libstdc++" to load modules that use scanner.cc instead of scanner.c.