### PR TITLE
Hack for tree-sitter-python

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable autocrlf
-        run: git config --global core.autocrlf false
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -20,6 +18,13 @@ jobs:
       - name: Update tree-sitter modules
         id: update
         run: |
+          cp gitattributes-hack python/.gitattributes
+          cd python
+          git status
+          git restore .gitattributes
+          git status
+          cd ..
+
           git status
           bash update.sh
 

--- a/gitattributes-hack
+++ b/gitattributes-hack
@@ -1,0 +1,8 @@
+src/*.json linguist-generated
+src/parser.c linguist-generated
+src/tree_sitter/* linguist-generated
+
+bindings/** linguist-generated
+binding.gyp linguist-generated
+setup.py linguist-generated
+Makefile linguist-generated


### PR DESCRIPTION
Some files in tree-sitter-python are marked as modified at the initial clone. To fix it, overwrite .gitattributes without "* text eol=lf" and run "git status".